### PR TITLE
Add support for pkgr builds

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -1,0 +1,2 @@
+targets:
+  ubuntu-16.04:

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+worker: yarn start

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
       "email": "lwosborne@mitre.org"
     }
   ],
+  "engines": {
+    "node": ">=9"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "start": "node server.js",


### PR DESCRIPTION
Cypress uses pkgr for building a .deb package for our distributed VMs. In order to instruct pkgr to build as we need, we need to add a Procfile, .pkgr.yml, and specify the supported engine versions (if we don't specify them it defaults to node 6 which fails).