### PR TITLE
Update cqm-execution ref and allow for cql-execution to be built on a branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,12 +10,13 @@ RUN ./docker_ssl_setup.sh; exit 0
 
 RUN apt-get update && apt-get install -y git-core
 
+# Bundle app source
+COPY . /usr/src/app
+
 WORKDIR /usr/src/app
 
 RUN yarn install --only=production
 
-# Bundle app source
-COPY . .
 
 EXPOSE 8081
 

--- a/bin/build_cql_execution.sh
+++ b/bin/build_cql_execution.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# If cql-execution/lib does not exist, build it from src.
+# This is needed if pointing to a cql-execution branch, as only the coffeescript
+# is included in the ./node_modules directory.
+if [ ! -d "./node_modules/cql-execution/lib" ]; then
+  yarn build-cql
+fi

--- a/package.json
+++ b/package.json
@@ -23,17 +23,19 @@
   },
   "license": "Apache-2.0",
   "scripts": {
+    "build-cql": "cd ./node_modules/cql-execution && yarn install && cd ../../",
     "start": "node server.js",
     "test": "mkdir -p coverage && NODE_ENV=test ./node_modules/nyc/bin/nyc.js --reporter=text-lcov --reporter=html mocha spec/server_spec.js > coverage/coverage.lcov",
     "testRunningServer": "mkdir -p coverage && NODE_ENV=test ./node_modules/nyc/bin/nyc.js --reporter=text-lcov --reporter=html mocha spec/server_spec_against_running.js > coverage/coverage-running.lcov",
     "docker-build": "docker build -t tacoma/cqm-execution-service .",
     "docker-run": "docker run --log-driver json-file --log-opt max-size=10m --log-opt max-file=4 -p 8081:8081 --name cqm-execution-service -d tacoma/cqm-execution-service",
     "docker-stop": "docker stop cqm-execution-service",
-    "docker-clean": "yarn docker-stop; docker rm cqm-execution-service"
+    "docker-clean": "yarn docker-stop; docker rm cqm-execution-service",
+    "prepublish": "./bin/build_cql_execution.sh"
   },
   "dependencies": {
     "compression": "^1.7.3",
-    "cqm-execution": "^1.0.2",
+    "cqm-execution": "https://github.com/projecttacoma/cqm-execution.git",
     "express": "^4.16.3",
     "winston": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -314,6 +314,11 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
+bson@^1.1.0, bson@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.0.tgz#bee57d1fb6a87713471af4e32bcae36de814b5b0"
+  integrity sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==
+
 bson@~1.0.4, bson@~1.0.5:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/bson/-/bson-1.0.9.tgz#12319f8323b1254739b7c6bef8d3e89ae05a2f57"
@@ -566,28 +571,28 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cql-execution@1.3.2:
+"cql-execution@https://github.com/cqframework/cql-execution.git":
   version "1.3.2"
-  resolved "https://registry.yarnpkg.com/cql-execution/-/cql-execution-1.3.2.tgz#3599ef31a0196e8ee679a37e1eee1911d731360b"
+  resolved "https://github.com/cqframework/cql-execution.git#17fb61f4be9b917d5e8ba5cde131d2845bc45d8a"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
-cqm-execution@^1.0.2:
+"cqm-execution@https://github.com/projecttacoma/cqm-execution.git":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cqm-execution/-/cqm-execution-1.0.2.tgz#2dffdbc6e65414c5e4861c0b0446ede5ad813ea7"
+  resolved "https://github.com/projecttacoma/cqm-execution.git#21a07efb9be9d46b46949d65b9d9b0c8bc4e8ab3"
   dependencies:
-    cqm-models "1.0.2"
+    cqm-models "https://github.com/projecttacoma/cqm-models#master"
     lodash "^4.17.5"
     moment "^2.21.0"
     mongoose "^5.0.7"
 
-cqm-models@1.0.2:
+"cqm-models@https://github.com/projecttacoma/cqm-models#master":
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-1.0.2.tgz#c337e13ad0608d970622adbe4bb5e9014560dfe5"
+  resolved "https://github.com/projecttacoma/cqm-models#c63b8818185f7ae886045e9e3451800482053af6"
   dependencies:
-    cql-execution "1.3.2"
-    mongoose "^5.0.7"
+    cql-execution "https://github.com/cqframework/cql-execution.git"
+    mongoose "^5.4.2"
 
 cross-spawn@^4:
   version "4.0.2"
@@ -1547,6 +1552,11 @@ kareem@2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.2.1.tgz#9950809415aa3cde62ab43b4f7b919d99816e015"
 
+kareem@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/kareem/-/kareem-2.3.0.tgz#ef33c42e9024dce511eeaf440cd684f3af1fc769"
+  integrity sha512-6hHxsp9e6zQU8nXsP+02HGWXwTkOEw6IROhF2ZA28cYbUk4eJ6QbtZvdqZOdD9YPKghG3apk5eOCvs+tLl3lRg==
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -1784,11 +1794,30 @@ mongodb-core@3.1.0:
   optionalDependencies:
     saslprep "^1.0.0"
 
+mongodb-core@3.1.11:
+  version "3.1.11"
+  resolved "https://registry.yarnpkg.com/mongodb-core/-/mongodb-core-3.1.11.tgz#b253038dbb4d7329f3d1c2ee5400bb0c9221fde5"
+  integrity sha512-rD2US2s5qk/ckbiiGFHeu+yKYDXdJ1G87F6CG3YdaZpzdOm5zpoAZd/EKbPmFO6cQZ+XVXBXBJ660sSI0gc6qg==
+  dependencies:
+    bson "^1.1.0"
+    require_optional "^1.0.1"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
 mongodb@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.1.tgz#c018c4b277614e8b1e08426d5bcbe1a7e5cdbd74"
   dependencies:
     mongodb-core "3.1.0"
+
+mongodb@3.1.13:
+  version "3.1.13"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.1.13.tgz#f8cdcbb36ad7a08b570bd1271c8525753f75f9f4"
+  integrity sha512-sz2dhvBZQWf3LRNDhbd30KHVzdjZx9IKC0L+kSZ/gzYquCF5zPOgGqRz6sSCqYZtKP2ekB4nfLxhGtzGHnIKxA==
+  dependencies:
+    mongodb-core "3.1.11"
+    safe-buffer "^5.1.2"
 
 mongoose-legacy-pluralize@1.0.2:
   version "1.0.2"
@@ -1811,9 +1840,32 @@ mongoose@^5.0.7:
     regexp-clone "0.0.1"
     sliced "1.0.1"
 
+mongoose@^5.4.2:
+  version "5.4.14"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.4.14.tgz#8cc074c9990db0a26062a779f461abb91c9c483c"
+  integrity sha512-lAISH4xdx0/o0bVWPB4bxApP3bA1b08oHPEjTBq3/mIr4R494hepDJJowByBgpGYf8tj/oe6VkFCx8wbRcOciA==
+  dependencies:
+    async "2.6.1"
+    bson "~1.1.0"
+    kareem "2.3.0"
+    mongodb "3.1.13"
+    mongodb-core "3.1.11"
+    mongoose-legacy-pluralize "1.0.2"
+    mpath "0.5.1"
+    mquery "3.2.0"
+    ms "2.1.1"
+    regexp-clone "0.0.1"
+    safe-buffer "5.1.2"
+    sliced "1.0.1"
+
 mpath@0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.4.1.tgz#ed10388430380bf7bbb5be1391e5d6969cb08e89"
+
+mpath@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mpath/-/mpath-0.5.1.tgz#17131501f1ff9e6e4fbc8ffa875aa7065b5775ab"
+  integrity sha512-H8OVQ+QEz82sch4wbODFOz+3YQ61FYz/z3eJ5pIdbMEaUzDqA268Wd+Vt4Paw9TJfvDgVKaayC0gBzMIw2jhsg==
 
 mquery@3.1.1:
   version "3.1.1"
@@ -1825,13 +1877,25 @@ mquery@3.1.1:
     regexp-clone "0.0.1"
     sliced "1.0.1"
 
+mquery@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/mquery/-/mquery-3.2.0.tgz#e276472abd5109686a15eb2a8e0761db813c81cc"
+  integrity sha512-qPJcdK/yqcbQiKoemAt62Y0BAc0fTEKo1IThodBD+O5meQRJT/2HSe5QpBNwaa4CjskoGrYWsEyjkqgiE0qjhg==
+  dependencies:
+    bluebird "3.5.1"
+    debug "3.1.0"
+    regexp-clone "0.0.1"
+    safe-buffer "5.1.2"
+    sliced "1.0.1"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.1.1:
+ms@2.1.1, ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
+  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
 mute-stream@0.0.7:
   version "0.0.7"
@@ -2298,7 +2362,7 @@ safe-buffer@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@5.1.2, safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 


### PR DESCRIPTION
Update reference to cqm-execution for min/max bug fix.

Add scripts to allow cql-execution to be built if pointing to a branch.  This is necessary as only published cql-execution has lib/ included.

Pull requests into cqm-execution-service require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1905
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @daco101
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
