### PR TITLE
No coded uncertainty

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "compression": "^1.7.3",
-    "cqm-execution": "https://github.com/projecttacoma/cqm-execution.git#no_coded_uncertainty",
+    "cqm-execution": "https://github.com/projecttacoma/cqm-execution.git#bonnie-patch",
     "express": "^4.16.3",
     "winston": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "compression": "^1.7.3",
-    "cqm-execution": "https://github.com/projecttacoma/cqm-execution.git#bonnie-v3.1.1",
+    "cqm-execution": "https://github.com/projecttacoma/cqm-execution.git#no_coded_uncertainty",
     "express": "^4.16.3",
     "winston": "^3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,27 +591,27 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
+"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-patch":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#94dc5f68b1d9e13e6bff5637d0f96aa132759c13"
+  resolved "https://github.com/cqframework/cql-execution.git#cc3cfe97e06d9804106149116e2bd599ad932611"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
-"cqm-execution@https://github.com/projecttacoma/cqm-execution.git#no_coded_uncertainty":
+"cqm-execution@https://github.com/projecttacoma/cqm-execution.git#bonnie-patch":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-execution.git#8d607a1fa8f5d96c89e51149880c7185915d30f4"
+  resolved "https://github.com/projecttacoma/cqm-execution.git#b74f59808729ed3e9b4c93b00b0bc103cf412684"
   dependencies:
-    cqm-models "https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty"
+    cqm-models "https://github.com/projecttacoma/cqm-models.git#bonnie-patch"
     lodash "^4.17.5"
     moment "^2.21.0"
     mongoose "^5.0.7"
 
-"cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
+"cqm-models@https://github.com/projecttacoma/cqm-models.git#bonnie-patch":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#0aeb882a068ce6cb739e1d73fa86503505bb528e"
+  resolved "https://github.com/projecttacoma/cqm-models.git#ed2ce3c13b5319ee2c4c25b0d4a1545bf935105c"
   dependencies:
-    cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
+    cql-execution "https://github.com/cqframework/cql-execution.git#bonnie-patch"
     mongoose "^5.0.7"
 
 cross-spawn@^4:

--- a/yarn.lock
+++ b/yarn.lock
@@ -591,27 +591,27 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cql-execution@https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1":
+"cql-execution@https://github.com/cqframework/cql-execution.git#no_coded_uncertainty":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#1f8976f2ce752925705887331de09caf46c86194"
+  resolved "https://github.com/cqframework/cql-execution.git#94dc5f68b1d9e13e6bff5637d0f96aa132759c13"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
-"cqm-execution@https://github.com/projecttacoma/cqm-execution.git#bonnie-v3.1.1":
+"cqm-execution@https://github.com/projecttacoma/cqm-execution.git#no_coded_uncertainty":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-execution.git#cc9feeb0d23fcea021c0be47acd18e7b50f898fd"
+  resolved "https://github.com/projecttacoma/cqm-execution.git#8d607a1fa8f5d96c89e51149880c7185915d30f4"
   dependencies:
-    cqm-models "https://github.com/projecttacoma/cqm-models.git#bonnie-v3.1.1"
+    cqm-models "https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty"
     lodash "^4.17.5"
     moment "^2.21.0"
     mongoose "^5.0.7"
 
-"cqm-models@https://github.com/projecttacoma/cqm-models.git#bonnie-v3.1.1":
+"cqm-models@https://github.com/projecttacoma/cqm-models.git#no_coded_uncertainty":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models.git#0a7234da0dc3c1a9be1c0a48722452bc6713bcfa"
+  resolved "https://github.com/projecttacoma/cqm-models.git#0aeb882a068ce6cb739e1d73fa86503505bb528e"
   dependencies:
-    cql-execution "https://github.com/cqframework/cql-execution.git#bonnie-v3.1.1"
+    cql-execution "https://github.com/cqframework/cql-execution.git#no_coded_uncertainty"
     mongoose "^5.0.7"
 
 cross-spawn@^4:


### PR DESCRIPTION
Hash updates for Bonnie patch release
Pull requests into cqm-execution-service require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/BONNIE-1938
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

