### PR TITLE
Updated yarn.lock with new mongoose, cqm-models and cqm-execution (#28)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9-slim
+FROM node:11-slim
 
 # Install app dependencies, including ssl_setup if it exists
 # A wildcard is used to ensure both package.json AND package-lock.json are copied

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,9 +268,9 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
 bson@^1.1.0, bson@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.0.tgz#bee57d1fb6a87713471af4e32bcae36de814b5b0"
-  integrity sha512-9Aeai9TacfNtWXOYarkFJRW2CWo+dRon+fuLZYJmvLV3+MiUp0bEI6IAZfXEIg7/Pl/7IWlLaDnhzTsD81etQA==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.1.tgz#4330f5e99104c4e751e7351859e2d408279f2f13"
+  integrity sha512-jCGVYLoYMHDkOsbwJZBCqwMHyH4c+wzgI9hG7Z6SZJRXWr+x58pdIbm2i9a/jFGCkRJqRUr8eoI7lDWa0hTkxg==
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -486,14 +486,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
 
 "cql-execution@https://github.com/cqframework/cql-execution.git":
   version "1.3.2"
-  resolved "https://github.com/cqframework/cql-execution.git#17fb61f4be9b917d5e8ba5cde131d2845bc45d8a"
+  resolved "https://github.com/cqframework/cql-execution.git#adf1649f119de0211fb48ee34eba9b07afaba19d"
   dependencies:
     moment "^2.20.1"
     ucum "0.0.7"
 
 "cqm-execution@https://github.com/projecttacoma/cqm-execution.git":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-execution.git#ded6f7b7c9f3afb372548eef2d7f78ab2a29a543"
+  resolved "https://github.com/projecttacoma/cqm-execution.git#ee3f8ea030c172d92b24c04abab38eb8c6d38cac"
   dependencies:
     cqm-models "https://github.com/projecttacoma/cqm-models#master"
     lodash "^4.17.5"
@@ -501,7 +501,7 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
 
 "cqm-models@https://github.com/projecttacoma/cqm-models#master":
   version "1.0.2"
-  resolved "https://github.com/projecttacoma/cqm-models#3b536e7ce9460400e708bec9879e79254597ba61"
+  resolved "https://github.com/projecttacoma/cqm-models#f73bd0aece7c95e952ea058073b9e3a88a88eeee"
   dependencies:
     cql-execution "https://github.com/cqframework/cql-execution.git"
     mongoose "^5.4.14"
@@ -1498,9 +1498,9 @@ mongoose-legacy-pluralize@1.0.2:
   integrity sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==
 
 mongoose@^5.4.14:
-  version "5.4.15"
-  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.4.15.tgz#5b6581ffb048b4c6ec6f5b9d792d759f3ba8eb02"
-  integrity sha512-CodfapidWmPlU93ZmdQ8H9UGg5Mc/5MqEy8y5zNQKw+Kp1UwOzSEJY6zXJW76/5MBQER859KHl3rvHijVMsUMg==
+  version "5.4.20"
+  resolved "https://registry.yarnpkg.com/mongoose/-/mongoose-5.4.20.tgz#8bc3720d082f07b535d2693f07ea3c2a7dc918a3"
+  integrity sha512-CyybxMQbCaq6jvbroamS5mPfFbxTOLLpdpkQrk1cj7Az1TX+mBbcCVhz+7XElfTMIOb58ah9O+EXmZJsLPD3Lg==
   dependencies:
     async "2.6.1"
     bson "~1.1.0"


### PR DESCRIPTION
* Updated yarn.lock with new mongoose, cqm-models and cqm-execution
* Updated docker base image to node:11-slim

Pull requests into cqm-execution-service require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
