### PR TITLE
update node version in dockerfile and dependency versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 # Install app dependencies, including ssl_setup if it exists
 # A wildcard is used to ensure both package.json AND package-lock.json are copied

--- a/package.json
+++ b/package.json
@@ -18,9 +18,6 @@
       "email": "lwosborne@mitre.org"
     }
   ],
-  "engines": {
-    "node": "20.14.x"
-  },
   "license": "Apache-2.0",
   "scripts": {
     "build-cql": "cd ./node_modules/cql-execution && yarn install && cd ../../",
@@ -35,8 +32,8 @@
   },
   "dependencies": {
     "compression": "^1.7.3",
-    "cqm-execution": "~4.3.0",
-    "cqm-models": "~4.2.1",
+    "cqm-execution": "~4.3.3",
+    "cqm-models": "~4.2.3",
     "express": "^4.16.3",
     "winston": "~3.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -618,7 +618,7 @@ cql-execution@2.4.1:
     "@lhncbc/ucum-lhc" "^4.1.3"
     luxon "^1.25.0"
 
-cqm-execution@~4.3.0:
+cqm-execution@~4.3.3:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/cqm-execution/-/cqm-execution-4.3.3.tgz#4621ade9f5ef438dd7bd918ad279d239af3acc79"
   integrity sha512-4BZSCAEWnHJ8dO1lTZ1hEThUg+xRaVuyFS6NbZQgEu6XFfxilikGE+gE0jMTJFXXvNGrP6AbZxSiiElY26lSrQ==
@@ -627,10 +627,18 @@ cqm-execution@~4.3.0:
     lodash "^4.17.19"
     moment "^2.29.4"
 
-cqm-models@4.2.3, cqm-models@~4.2.1:
+cqm-models@4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-4.2.3.tgz#0aa4405addf0d83ab7d2d2cf4e78b6f4aa17c574"
   integrity sha512-Wa8GZTvn9ysI/g9zbuksyvUWiXOhCkmoQGj+Q/2/caBIG/9XFjLO67QrvkfXuojIBNKMMl9MSBTmYXm/Aomf5w==
+  dependencies:
+    cql-execution "2.4.1"
+    mongoose "^7.8.4"
+
+cqm-models@~4.2.3:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/cqm-models/-/cqm-models-4.2.4.tgz#8e928c3a3f3a2861dcde5f393129255291c77705"
+  integrity sha512-ZCC+3w/+D+9GU9mkxunnzCsDpebO3uDpOuZB2DO/uO2Mm6w7y3XAlZbqcMt0C/2DTY3wrO6yTTB/p0XKxU6qog==
   dependencies:
     cql-execution "2.4.1"
     mongoose "^7.8.4"


### PR DESCRIPTION
Dockerfile was not successfully building previously. I updated the node version, and also updated the dependency versions related to the 'yarn.lock' update. To test building, run `docker build -t cqm-execution-service:dev .`. If running behind MITRE network, switch to branch `feat/mitre-internal-build-deploy`, which include additional necessary steps in dockerfile to build the image behind the company's proxy. that branch will never be merged but stay up to day with the latest `cypress_v7` branch.



Pull requests into cqm-execution-service require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
