### PR TITLE
specify node version 22.16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
       "email": "lwosborne@mitre.org"
     }
   ],
+  "engines": {
+    "node": "22.16.x"
+  },
   "license": "Apache-2.0",
   "scripts": {
     "build-cql": "cd ./node_modules/cql-execution && yarn install && cd ../../",


### PR DESCRIPTION
Pull requests into cqm-execution-service require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
