### PR TITLE
allow flexible node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "engines": {
-    "node": "22.16.x"
+    "node": "^22.16.x"
   },
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
I updated the package.json file to allow for newer minor node versions, otherwise the dockerfile, using the latest 22.17 node base image, won't successfully build. I would have updated the yarn.lock file but it didnt change with the node version.

<img width="2294" height="1106" alt="image" src="https://github.com/user-attachments/assets/b15b0864-47e6-4f50-b4c4-af0fe36ac14a" />




Pull requests into cqm-execution-service require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
